### PR TITLE
Fix username validation

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -35,7 +35,7 @@ namespace FortniteStatsAnalyzer.Controllers
 
             var stats = await _fortniteStatsService.GetStatsForUser(username);
 
-            if (stats == null)
+            if (stats == null || !stats.Result)
             {
                 _logger.LogWarning("Validation failed: No stats found for username '{Username}'", username);
                 return Json(new { success = false, message = "Invalid username. Please try again." });


### PR DESCRIPTION
## Summary
- detect invalid usernames by checking API result

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be4723254832a8fdac346308cef79