### PR TITLE
Add xUnit tests for FortniteApiService

### DIFF
--- a/FortniteStatsAnalyzer.Tests/FortniteApiServiceTests.cs
+++ b/FortniteStatsAnalyzer.Tests/FortniteApiServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FortniteStatsAnalyzer.Configuration;
+using FortniteStatsAnalyzer.Models;
+using FortniteStatsAnalyzer.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace FortniteStatsAnalyzer.Tests;
+
+public class FortniteApiServiceTests
+{
+    private class TestMessageHandler : HttpMessageHandler
+    {
+        public bool WasCalled { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            WasCalled = true;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+
+    [Fact]
+    public async Task GetStatsForUser_EmptyUsername_ReturnsFailure()
+    {
+        var options = Options.Create(new FortniteApiSettings { ApiKey = "dummy" });
+        var handler = new TestMessageHandler();
+        var client = new HttpClient(handler);
+        var service = new FortniteApiService(options, new NullLogger<FortniteApiService>(), client);
+
+        var result = await service.GetStatsForUser(string.Empty);
+
+        Assert.False(result?.Result);
+        Assert.Equal("Username cannot be empty", result?.Error);
+        Assert.False(handler.WasCalled);
+    }
+}

--- a/FortniteStatsAnalyzer.Tests/FortniteStatsAnalyzer.Tests.csproj
+++ b/FortniteStatsAnalyzer.Tests/FortniteStatsAnalyzer.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FortniteStatsAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FortniteStatsAnalyzer.Tests/GlobalUsings.cs
+++ b/FortniteStatsAnalyzer.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/FortniteStatsAnalyzer.csproj
+++ b/FortniteStatsAnalyzer.csproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <!-- Exclude test project files from main compilation -->
+  <ItemGroup>
+    <Compile Remove="FortniteStatsAnalyzer.Tests\**\*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/FortniteStatsAnalyzer.sln
+++ b/FortniteStatsAnalyzer.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FortniteStatsAnalyzer", "FortniteStatsAnalyzer.csproj", "{CBB8F8C5-81B7-4681-AC1E-8F46CB2AF38D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FortniteStatsAnalyzer.Tests", "FortniteStatsAnalyzer.Tests\FortniteStatsAnalyzer.Tests.csproj", "{E8DE8830-D94C-4FDB-AFF3-DFE1952F667A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{CBB8F8C5-81B7-4681-AC1E-8F46CB2AF38D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBB8F8C5-81B7-4681-AC1E-8F46CB2AF38D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBB8F8C5-81B7-4681-AC1E-8F46CB2AF38D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8DE8830-D94C-4FDB-AFF3-DFE1952F667A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8DE8830-D94C-4FDB-AFF3-DFE1952F667A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8DE8830-D94C-4FDB-AFF3-DFE1952F667A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8DE8830-D94C-4FDB-AFF3-DFE1952F667A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Services/FortniteApiService.cs
+++ b/Services/FortniteApiService.cs
@@ -25,16 +25,25 @@ namespace FortniteStatsAnalyzer.Services
 
         public FortniteApiService(
             IOptions<FortniteApiSettings> fortniteSettings,
-            ILogger<FortniteApiService> logger)
+            ILogger<FortniteApiService> logger,
+            HttpClient httpClient)
         {
             _fortniteApiKey = fortniteSettings?.Value?.ApiKey?.Trim() ?? throw new InvalidOperationException("Fortnite API key is not set correctly in configuration.");
             _logger = logger;
-            _client = new HttpClient();
-            
+            _client = httpClient;
+
             // Set up the headers once in constructor
             _client.DefaultRequestHeaders.Clear();
             _client.DefaultRequestHeaders.Add("Authorization", _fortniteApiKey);
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        // Parameterless HttpClient constructor for backward compatibility and simpler instantiation
+        public FortniteApiService(
+            IOptions<FortniteApiSettings> fortniteSettings,
+            ILogger<FortniteApiService> logger)
+            : this(fortniteSettings, logger, new HttpClient())
+        {
         }
 
         public async Task<FortniteStatsResponse?> GetStatsForUser(string username)


### PR DESCRIPTION
## Summary
- add FortniteStatsAnalyzer.Tests xUnit project
- make HttpClient injectable for FortniteApiService
- prevent main project from compiling test files
- verify empty username returns failure in FortniteApiService

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684be7bea368832a87b91b67d07c541e