### PR TITLE
Fix progress pct naming

### DIFF
--- a/Models/FortniteStatsResponse.cs
+++ b/Models/FortniteStatsResponse.cs
@@ -102,7 +102,7 @@ namespace FortniteStatsAnalyzer.Models
         [JsonProperty("level")]
         public int Level { get; set; }
 
-        [JsonProperty("process_pct")]
-        public int ProcessPct { get; set; }
+        [JsonProperty("progress_pct")]
+        public int ProgressPct { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- fix a typo in the AccountLevel properties

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684be9860784832a9e4643fab443f946